### PR TITLE
Correctly handle all_on_start option

### DIFF
--- a/lib/guard/slimlint.rb
+++ b/lib/guard/slimlint.rb
@@ -3,15 +3,16 @@ require 'colorize'
 
 module Guard
   class SlimLint < Plugin
-    attr_accessor :notify_on
+    attr_accessor :notify_on, :all_on_start
 
     def initialize(options = {})
-      @notify_on = options[:notify_on] ? options[:notify_on] : :failure
+      @notify_on    = options.fetch(:notify_on, :failure)
+      @all_on_start = options.fetch(:all_on_start, true)
       super
     end
 
     def start
-      run
+      run_all if all_on_start
     end
 
     def run_all

--- a/spec/guard/slimlint_spec.rb
+++ b/spec/guard/slimlint_spec.rb
@@ -42,6 +42,26 @@ RSpec.describe Guard::SlimLint do
     end
   end
 
+  describe '#start' do
+    context 'when :all_on_start option is enabled' do
+      subject { described_class.new(all_on_start: true) }
+
+      it 'runs all' do
+        expect(subject).to receive(:run_all)
+        subject.start
+      end
+    end
+
+    context 'when :all_on_start option is disabled' do
+      subject { described_class.new(all_on_start: false) }
+
+      it 'does nothing' do
+        expect(subject).not_to receive(:run_all)
+        subject.start
+      end
+    end
+  end
+
   describe 'notifiers' do
     context 'when option set on :none' do
       subject { described_class.new(notify_on: :none) }


### PR DESCRIPTION
Only execute `run_all` on start if option is set to true (default)